### PR TITLE
Add option aws-use-default-credentials-provider-chain

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -5,6 +5,8 @@ s3-client {
   # The AWS secret to use in conjuction with the AWS key ID.
   aws-secret-access-key = ""
 
+  aws-use-default-credentials-provider-chain = false
+
   region = ""
 
   endpoint = "default"

--- a/src/main/scala/akka/persistence/s3/S3Client.scala
+++ b/src/main/scala/akka/persistence/s3/S3Client.scala
@@ -2,7 +2,7 @@ package akka.persistence.s3
 
 import java.io.InputStream
 
-import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.auth.{ BasicAWSCredentials, DefaultAWSCredentialsProviderChain }
 import com.amazonaws.services.s3.{ S3ClientOptions, AmazonS3Client }
 import com.amazonaws.services.s3.model._
 
@@ -12,7 +12,12 @@ trait S3Client {
   val s3ClientConfig: S3ClientConfig
 
   lazy val client: AmazonS3Client = {
-    val client = new AmazonS3Client(new BasicAWSCredentials(s3ClientConfig.awsKey, s3ClientConfig.awsSecret))
+    val client =
+      if (s3ClientConfig.awsUseDefaultCredentialsProviderChain)
+        new AmazonS3Client(new DefaultAWSCredentialsProviderChain).withRegion(s3ClientConfig.region)
+      else
+        new AmazonS3Client(new BasicAWSCredentials(s3ClientConfig.awsKey, s3ClientConfig.awsSecret))
+
     s3ClientConfig.endpoint.foreach { endpoint =>
       client.withEndpoint(endpoint)
       ()

--- a/src/main/scala/akka/persistence/s3/S3Config.scala
+++ b/src/main/scala/akka/persistence/s3/S3Config.scala
@@ -22,6 +22,7 @@ class S3ClientConfig(config: Config) {
   import AWSRegionNames._
   val awsKey = config getString "aws-access-key-id"
   val awsSecret = config getString "aws-secret-access-key"
+  val awsUseDefaultCredentialsProviderChain = config getBoolean "aws-use-default-credentials-provider-chain"
   val region: Region = config getString "region" match {
     case GovCloud       => Region.getRegion(Regions.GovCloud)
     case US_EAST_1      => Region.getRegion(Regions.US_EAST_1)


### PR DESCRIPTION
Explicit setting of (awsKey, awsSecret) pair seemed to fail in implicit authentication & authorization based on EC2 instance profile (IAM role). So I added an option to use AWS default credentials provider chain to make it work in such a situation.

Tested with local s3 server (s3rver).
